### PR TITLE
Fix null reference exception when trying to explore object in a scene

### DIFF
--- a/Assets/Editor/AssetDependencyGraph.cs
+++ b/Assets/Editor/AssetDependencyGraph.cs
@@ -104,6 +104,10 @@ public class AssetDependencyGraph : EditorWindow
 
     private void ExplodeAsset()
     {
+        Transform tr = Selection.activeTransform;
+        if (tr)
+            return;
+
         Object obj = Selection.activeObject;
         if (!obj)
             return;


### PR DESCRIPTION
### Summary
Check `Selection.activeTransform` to early return from `ExplodeAsset` if active transform is not null. For objects selected in project view active transform is null, for objects in the scene it's not (also for objects selected in prefab view it's not null).

### How to reproduce exception
Open any scene and select object in the scene hierarchy. Click "Explore Asset" button and observe exception. This is caused by `ExplodeAsset` failed to load selected asset properly with `assetPath` being empty string and `mainObject` being null.