### PR TITLE
Add toolbar search field for nodes, small fixes when "refreshing"

### DIFF
--- a/AssetDependencyGraph/Editor/AssetDependencyGraph.cs
+++ b/AssetDependencyGraph/Editor/AssetDependencyGraph.cs
@@ -99,7 +99,7 @@ public class AssetDependencyGraph : EditorWindow
             m_GraphView.ClearSelection();
             // m_GraphView.graphElements.ForEach(y => { // BROKEN, Case 1268337
             m_GraphView.graphElements.ToList().ForEach(y => {
-                if (y is Node node && y.title.Contains(x.newValue)) {
+                if (y is Node node && y.title.IndexOf(x.newValue, StringComparison.OrdinalIgnoreCase) >= 0) {
                     m_GraphView.AddToSelection(node);
                 }
             });


### PR DESCRIPTION
Adds a little toolbar search field:
![image](https://user-images.githubusercontent.com/2693840/89398745-cd7a9480-d711-11ea-89e6-7ee685ec7144.png)

Search selects and frames nodes with titles containing the search string for now.
Possible future improvements would be tapping into the search provider etc, but already feels more manageable in complex graphs.